### PR TITLE
Remove doctests from GHA

### DIFF
--- a/.github/workflows/Docs.yaml
+++ b/.github/workflows/Docs.yaml
@@ -3,10 +3,10 @@ name: Docs
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
     tags: '*'
 
 jobs:

--- a/.github/workflows/Docs.yaml
+++ b/.github/workflows/Docs.yaml
@@ -23,14 +23,6 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-      - run: |
-          julia --project=docs/ -e '
-            using ResNetImageNet
-            # using Pkg; Pkg.activate("docs")
-            using Documenter
-            using Documenter: doctest
-            DocMeta.setdocmeta!(ResNetImageNet, :DocTestSetup, :(using ResNetImageNet); recursive=true)
-            doctest(ResNetImageNet)'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ makedocs(modules = [ResNetImageNet],
          sitename = "Data Parallel Training",
          pages = ["Home" => "index.md",
                   "Training" => "training.md",
-                  "Datasets" => "datasets.md"]
+                  "Datasets" => "datasets.md"],
          format = Documenter.HTML(
              analytics = "UA-36890222-9",
              assets = ["assets/flux.css"],


### PR DESCRIPTION
The repo doesn't contain test as of now since its difficult to have multi-gpu environments for CI at the moment. We can reinstate this once we have the tests added back in. 