### PR TITLE
Use task based learning instead

### DIFF
--- a/src/ResNetImageNet.jl
+++ b/src/ResNetImageNet.jl
@@ -14,5 +14,6 @@ include("utils.jl")
 include("overloads.jl")
 include("imagenet.jl")
 include("sync.jl")
+include("ddp_tasks.jl")
 
 end # module

--- a/src/ResNetImageNet.jl
+++ b/src/ResNetImageNet.jl
@@ -8,6 +8,7 @@ using Dates, DataSets
 using Functors, Optimisers
 
 export minibatch, train_solutions, syncgrads
+export prepare_training
 
 # include("test.jl")
 include("utils.jl")

--- a/src/ResNetImageNet.jl
+++ b/src/ResNetImageNet.jl
@@ -11,10 +11,11 @@ export minibatch, train_solutions, syncgrads
 export prepare_training
 
 # include("test.jl")
+include("preprocess.jl")
 include("utils.jl")
 include("overloads.jl")
 include("imagenet.jl")
-include("sync.jl")
+# include("sync.jl")
 include("ddp_tasks.jl")
 
 end # module

--- a/src/ddp_tasks.jl
+++ b/src/ddp_tasks.jl
@@ -1,15 +1,11 @@
-# t = map(0:3) do i
-#   (500, CUDA.CuDevice(i))
-# end
-# 
-# dl = Flux.Data.DataLoader((t,))
-
 # function sth(model, key, devices, nsamples)
 #   t = map(devices, nsamples) do dev, n
 #     (dev, n)
 #   end |> x -> (x...,)
 # 
+#   @show t
 #   dl = Flux.Data.DataLoader((t,)) do (dev, n)
+#     @show n, dev
 #     Threads.@spawn begin
 #       data = minibatch(nothing, key,
 #                        nsamples = n,
@@ -25,48 +21,81 @@
 #   end
 # end
 
-export prepare_training, train_ddp
 
-function prepare_training(resnet, key, devices, nsamples)
-  data = minibatch(nothing, key, nsamples = nsamples, class_idx = 1:1000)
-  shards = Flux.Data.DataLoader(data, batchsize = nsamples ÷ length(devices))
+_zero(x::AbstractArray) = zero(x)
+_zero(x::Base.RefValue) = Ref(_zero(x[]))
+_zero(x) = x
+
+function destruct(o::T) where T
+  fs = fieldnames(T)
+  z = Functors.fmapstructure(o) do x
+    _zero(x)
+  end
+  NamedTuple{fs}(tuple(z))
+end
+
+function prepare_training(resnet, key, devices, nsamples; HOST = CUDA.CuDevice(0))
   ds = Dict()
-  @sync for (dev, shard) in zip(devices, shards)
+  ixs = map(shuffle!, collect.(collect(Iterators.partition(1:size(key, 1), size(key, 1) ÷ length(devices)))))[1:length(devices)]
+  ks = map(x -> @view(key[x,:]), ixs)
+  # @sync for (dev, shard) in zip(devices, shards)
+  ns = ntuple(_ -> nsamples, 20) # length(devices))
+  buffer = Dict()
+  zmodel = destruct(resnet)
+  for dev in devices
     Threads.@spawn begin
-      ds[dev] = CUDA.device!(dev) do
-        gpu(resnet),
-        Flux.Data.DataLoader(gpu, shard, batchsize = 48)
+      buffer[dev] = CUDA.device!(HOST) do
+        gpu(zmodel)
       end
     end
   end
-  ds
-end
-
-function train(loss, dev, m, dl)
-  CUDA.device!(dev) do
-    @info "going to forward" CUDA.device()
-    for d in dl
-      x, y = d
-      # gradient(m) do m
-      #   loss(m(x), y)
-      # end
-      # @info "going to forward" CUDA.device() typeof(d)
-      # @show loss(m(x), y)
-      @show size(x), size(y)
+  for (k,dev) in zip(ks, devices)
+    Threads.@spawn begin
+      ds[dev] = CUDA.device!(dev) do
+        gpu(resnet),
+        Flux.Data.DataLoader((ns,), buffersize = 5) do x
+          shard = minibatch(nothing, k, nsamples = x, class_idx = 1:1000)
+          CUDA.device!(dev) do
+            gpu(shard)
+          end
+        end
+      end
     end
   end
+  ds, buffer
 end
 
-function train_ddp(loss, ds)
-  res = []
-  for (dev, (m, d)) in pairs(ds)
-    t = Threads.@spawn begin
-      train(loss, dev, m, d)
-    end
-    push!(res, t)
-  end
-  wait.(res)
-end
+# function train(loss, dev, m, dl)
+#   CUDA.device!(dev) do
+#     @info "going to forward" CUDA.device()
+#     for d in dl
+#       x, y = d
+#       # gradient(m) do m
+#       #   loss(m(x), y)
+#       # end
+#       # @info "going to forward" CUDA.device() typeof(d)
+#       # @show loss(m(x), y)
+#       @show size(x), size(y)
+#     end
+#   end
+# end
+# 
+# function train_ddp(loss, ds)
+#   res = []
+#   for (dev, (m, d)) in pairs(ds)
+#     t = Threads.@spawn begin
+#       # CUDA.device!(dev) do
+#       #   @show CUDA.device()
+#         train(loss, dev, m, d)
+#       # end
+#     end
+#     push!(res, t)
+#   end
+#   @show "ended stuff"
+#   wait.(res)
+# end
+
+
 
 function train(loss, m, dl, opt, dev, (ip, op))
   # STEP 1: Take data from dataloader: this data is on `dev`
@@ -89,9 +118,75 @@ function train(loss, m, dl, opt, dev, (ip, op))
     # This happens since `x` is on this `dev` and CUDA does appropriate DtoD
     gmnew = Functors.fmap(gm, op) do x, y
       copyto!(x, y)
+      x
     end
 
     # STEP 5: Optimise. `m`, `gmnew` and `state` are all on `dev` and should return new `m`
     m, state = opt(m, gmnew, state)
   end
+end
+
+_copyto!(::Nothing, ::Nothing) = nothing
+_copyto!(x::Base.RefValue, y::Base.RefValue) = Ref(_copyto!(x[], yp[]))
+_copyto!(x, y) = copyto!(x, y)
+
+function markbuffer!(dest, src, dev)
+  while true
+    if buffer_is_writable()
+      mark!(MARKER, dev)
+      Functors.fmap(dest, src) do x, y
+        _copyto!(x, y)
+      end
+      break
+    end
+  end
+end
+
+function check(MARKER, dev, writable)
+  # Threads.atomic_cas!(MARKER[dev], writable, false)
+end
+
+function canread end
+function canwrite end
+
+"""
+    mark!(MARKER, dev)
+
+Mark that dev is changing state in MARKER
+
+MARKER is a Dict with keys as all the devices and the values being 2-tuples of atomic booleans which represent (hot gradient, can be overwritten)
+"""
+function mark!(MARKER, dev)
+  
+end
+
+function getbuffer!(dest, buffer, dev)
+  check(MARKER, dev, true)
+  Functors.fmap(dest, buffer[dev]) do x, y
+    _copyto!(x, y)
+  end
+  mark!(MARKER, dev)
+end
+
+# implementation of the `train` function from above
+# with actual semantics baked in
+# intended to be moved to the train method as pieces finish
+function train(setup, buffer, HOST = CUDA.CuDevice(0))
+  ts = []
+  for (dev,(m,v)) in pairs(setup)
+    t = Threads.@spawn begin
+      for (x,y) in v # STEP 1
+    
+        gm, = CUDA.device!(k) do # STEP 2
+          gradient(m -> ResNetImageNet.loss(m(x), y), m)
+        end
+        markbuffer!(buffer[k], gm, dev) # STEP 3
+        getbuffer!(gm, dev) # STEP 4
+        m, st = opt(m, gm, st) # STEP 5
+        @info "results:" dev=k nt=isa(gs, NamedTuple) s=sum(m(x)) t=(typeof(x), typeof(y)) host=HOST
+      end
+    end
+    push!(ts, t)
+  end
+  ts
 end

--- a/src/ddp_tasks.jl
+++ b/src/ddp_tasks.jl
@@ -1,0 +1,69 @@
+# t = map(0:3) do i
+#   (500, CUDA.CuDevice(i))
+# end
+# 
+# dl = Flux.Data.DataLoader((t,))
+
+# function sth(model, key, devices, nsamples)
+#   t = map(devices, nsamples) do dev, n
+#     (dev, n)
+#   end |> x -> (x...,)
+# 
+#   dl = Flux.Data.DataLoader((t,)) do (dev, n)
+#     Threads.@spawn begin
+#       data = minibatch(nothing, key,
+#                        nsamples = n,
+#                        class_idx = 1:1000)
+#       dl2 = Flux.Data.DataLoader(data,
+#                                  batchsize = 48) do x
+#         CUDA.device!(dev) do
+#           @show CUDA.device()
+#           gpu(x)
+#         end
+#       end
+#     end
+#   end
+# end
+
+export prepare_training, train_ddp
+
+function prepare_training(resnet, key, devices, nsamples)
+  data = minibatch(nothing, key, nsamples = nsamples, class_idx = 1:1000)
+  shards = Flux.Data.DataLoader(data, batchsize = nsamples ÷ length(devices))
+  ds = Dict()
+  @sync for (dev, shard) in zip(devices, shards)
+    Threads.@spawn begin
+      ds[dev] = CUDA.device!(dev) do
+        gpu(resnet),
+        Flux.Data.DataLoader(gpu, shard, batchsize = 48)
+      end
+    end
+  end
+  ds
+end
+
+function train(loss, dev, m, dl)
+  CUDA.device!(dev) do
+    @info "going to forward" CUDA.device()
+    for d in dl
+      x, y = d
+      # gradient(m) do m
+      #   loss(m(x), y)
+      # end
+      # @info "going to forward" CUDA.device() typeof(d)
+      # @show loss(m(x), y)
+      @show size(x), size(y)
+    end
+  end
+end
+
+function train_ddp(loss, ds)
+  res = []
+  for (dev, (m, d)) in pairs(ds)
+    t = Threads.@spawn begin
+      train(loss, dev, m, d)
+    end
+    push!(res, t)
+  end
+  wait.(res)
+end

--- a/src/ddp_tasks.jl
+++ b/src/ddp_tasks.jl
@@ -127,6 +127,8 @@ function log_loss_and_acc(loss, (dev, model), val; k = (1,5,10))
   end
 end
 
+loss(x, y) = -sum(y .* Flux.logsoftmax(x) ) ./ Float32(size(y,2))
+
 function train(loss, nt, buffer, opt; val = nothing)
   dls = nt.dls
   ds_and_ms = nt.ds_and_ms

--- a/src/ddp_tasks.jl
+++ b/src/ddp_tasks.jl
@@ -44,36 +44,38 @@ function destruct(o::T) where T
   end
 end
 
-function prepare_training(resnet, key, devices, nsamples; HOST = CUDA.CuDevice(0))
+function prepare_training(resnet, key, devices, opt, nsamples; HOST = CUDA.CuDevice(0))
   ds = Dict()
   ixs = map(shuffle!, collect.(collect(Iterators.partition(1:size(key, 1), size(key, 1) ÷ length(devices)))))[1:length(devices)]
   ks = map(x -> @view(key[x,:]), ixs)
-  # @sync for (dev, shard) in zip(devices, shards)
-  ns = ntuple(_ -> nsamples, 20) # length(devices))
+  ns = Iterators.repeated(nsamples, 25) # ntuple(_ -> nsamples, 5) # length(devices))
   buffer = Dict()
   zmodel = destruct(resnet)
+  st = Optimisers.init(opt, resnet)
   for dev in devices
     Threads.@spawn begin
       buffer[dev] = CUDA.device!(HOST) do
-        gpu(zmodel)
+        gpu(zmodel), gpu(st)
       end
     end
   end
+  dls = []
+  devs_and_ms = []
   for (k,dev) in zip(ks, devices)
-    Threads.@spawn begin
-      ds[dev] = CUDA.device!(dev) do
-        gpu(resnet),
-        Flux.Data.DataLoader((ns,), buffersize = 5) do x
-          shard = minibatch(nothing, k, nsamples = x, class_idx = 1:1000)
-          CUDA.device!(dev) do
-            gpu(shard)
-          end
+    CUDA.device!(dev) do
+      push!(devs_and_ms, (dev, gpu(resnet)))
+      dl = Flux.Data.DataLoader((ns,), buffersize = 5) do x
+        shard = minibatch(nothing, k, nsamples = x, class_idx = 1:1000)
+        CUDA.device!(dev) do
+          gpu(shard)
         end
       end
+      push!(dls, dl)
     end
   end
-  ds, buffer
+  (ds_and_ms = devs_and_ms, dls = dls), buffer
 end
+
 
 # function train(loss, dev, m, dl)
 #   CUDA.device!(dev) do
@@ -104,8 +106,6 @@ end
 #   @show "ended stuff"
 #   wait.(res)
 # end
-
-
 
 function train(loss, m, dl, opt, dev, (ip, op))
   # STEP 1: Take data from dataloader: this data is on `dev`
@@ -143,76 +143,61 @@ _copyto!(x, ::Nothing) = nothing
 _copyto!(::Nothing, x) = nothing
 
 function markbuffer!(dest, src, dev)
-  while true
-    if check(MARKER, dev, writable)
-      break
-    end
-  end
   Functors.fmap(src, dest) do x, y
     _copyto!(y, x)
     x
   end
-  mark!(MARKER, dev, readable)
-end
-
-function check(MARKER, dev, status)
-  MARKER[dev][] == status
-end
-
-"""
-    mark!(MARKER, dev)
-
-Mark that dev is changing state in MARKER
-
-MARKER is a Dict with keys as all the devices and the values being 2-tuples of atomic booleans which represent (hot gradient, can be overwritten)
-"""
-function mark!(MARKER, dev, status)
-  Threads.atomic_xchg!(MARKER[dev], status)  
 end
 
 function getbuffer!(dest, src, dev)
-  while true
-    if check(MARKER, dev, readable)
-      break
-    end
-  end
   Functors.fmap(dest, src) do x, y
     _copyto!(x, y)
     x
   end
-  mark!(MARKER, dev, writable)
 end
 
-const writable = true
-const readable = false
-const MARKER = Dict(dev => Threads.Atomic{Bool}(writable) for dev in CUDA.devices())
-
-function reset!(MARKER)
-  for k in keys(MARKER)
-    mark!(MARKER, k, writable)
+function sync_buffer(buffer)
+  vals = map(first, values(buffer))
+  # vals = collect(values(buffer))
+  final = reduce(vals[2:end], init = vals[1]) do x,y
+    Functors.fmap(x, y) do x, y
+       isnothing(x) && return y
+       isnothing(y) && return x
+       _accum(x,y)
+    end
   end
+end
+
+function step(buffer, dev, m, x, y)
+  gs, = CUDA.device!(dev) do
+    gradient(m -> ResNetImageNet.loss(m(x), y), m)
+  end
+  markbuffer!(first(buffer[dev]), gs, dev)
+  # markbuffer!(buffer[dev], gs, dev)
+  gs
 end
 
 # implementation of the `train` function from above
 # with actual semantics baked in
 # intended to be moved to the train method as pieces finish
 function train(setup, buffer, HOST = CUDA.CuDevice(0))
-  ts = []
-  reset!(MARKER)
-  for (dev,(m,dl)) in pairs(setup)
+  dls = nt.dls
+  ds_and_ms = nt.ds_and_ms
+  big_batches = zip(dls...)
+  for mbs in big_batches
     t = Threads.@spawn begin
-      for (x,y) in dl # STEP 1
-    
-        gm, = CUDA.device!(dev) do # STEP 2
-          gradient(m -> ResNetImageNet.loss(m(x), y), m)
-        end
-        markbuffer!(buffer[dev], gm, dev) # STEP 3
-        getbuffer!(gm, buffer[dev], dev) # STEP 4
-        m, st = opt(m, gm, st) # STEP 5
-        @info "results:" dev=dev nt=isa(gs, NamedTuple) s=sum(m(x)) t=(typeof(x), typeof(y)) host=HOST
+      t_ = map(ds_and_ms, mbs) do (dev, m), bs
+        @info "results:" dev=dev host=HOST
+        gs = Threads.@spawn step(buffer, dev, m, bs...)
       end
     end
-    push!(ts, t)
+    gs = fetch(t)
+    wait.(gs)
+    final = sync_buffer(buffer)
+    get_tasks = map(ds_and_ms, gs) do dnm, g
+     dev, m = dnm
+     get_task = Threads.@spawn getbuffer!(fetch(g), final, dev)
+    end
+    ts = fetch.(get_tasks)
   end
-  ts
 end

--- a/src/ddp_tasks.jl
+++ b/src/ddp_tasks.jl
@@ -1,31 +1,45 @@
-# function sth(model, key, devices, nsamples)
-#   t = map(devices, nsamples) do dev, n
-#     (dev, n)
-#   end |> x -> (x...,)
-# 
-#   @show t
-#   dl = Flux.Data.DataLoader((t,)) do (dev, n)
-#     @show n, dev
-#     Threads.@spawn begin
-#       data = minibatch(nothing, key,
-#                        nsamples = n,
-#                        class_idx = 1:1000)
-#       dl2 = Flux.Data.DataLoader(data,
-#                                  batchsize = 48) do x
-#         CUDA.device!(dev) do
-#           @show CUDA.device()
-#           gpu(x)
-#         end
-#       end
-#     end
-#   end
+# using ResNetImageNet, Flux, Flux.CUDA, BSON, Flux.Zygote, Metalhead, Functors, Serialization, Statistics, Random
+# using DataFrames, CSV, Dates, DataSets
+
+using Serialization, Statistics, Random
+using .Threads
+
+# t = map(0:1) do i
+#   (500, CUDA.CuDevice(i))
 # end
+# 
+# dl = Flux.Data.DataLoader((t,))
+
+function sth(model, key, devices, nsamples)
+  t = map(devices, nsamples) do dev, n
+    (dev, n)
+  end |> x -> (x...,)
+
+  @show t
+  dl = Flux.Data.DataLoader((t,)) do (dev, n)
+    @show n, dev
+    Threads.@spawn begin
+      data = minibatch(nothing, key,
+                       nsamples = n,
+                       class_idx = 1:1000)
+      dl2 = Flux.Data.DataLoader(data,
+                                 batchsize = 48) do x
+        CUDA.device!(dev) do
+          @show CUDA.device()
+          gpu(x)
+        end
+      end
+    end
+  end
+end
 
 
 _zero(x::AbstractArray) = zero(x)
 _zero(x::Base.RefValue) = Ref(_zero(x[]))
+_zero(x::Function) = nothing
+_zero(x::T) where T <: Union{MaxPool, AdaptiveMeanPool, Flux.Zeros} = nothing
 _zero(x) = x
-
+_zero(x::Real) = nothing
 
 maybeT(x::NamedTuple) = x
 maybeT(x) = (x,)
@@ -44,68 +58,37 @@ function destruct(o::T) where T
   end
 end
 
-function prepare_training(resnet, key, devices, opt, nsamples; HOST = CUDA.CuDevice(0))
-  ds = Dict()
-  ixs = map(shuffle!, collect.(collect(Iterators.partition(1:size(key, 1), size(key, 1) ÷ length(devices)))))[1:length(devices)]
-  ks = map(x -> @view(key[x,:]), ixs)
-  ns = Iterators.repeated(nsamples, 25) # ntuple(_ -> nsamples, 5) # length(devices))
-  buffer = Dict()
-  zmodel = destruct(resnet)
-  st = Optimisers.init(opt, resnet)
-  for dev in devices
-    Threads.@spawn begin
-      buffer[dev] = CUDA.device!(HOST) do
-        gpu(zmodel), gpu(st)
-      end
+function train(loss, dev, m, dl)
+  CUDA.device!(dev) do
+    @info "going to forward" CUDA.device()
+    for d in dl
+      x, y = d
+      # gradient(m) do m
+      #   loss(m(x), y)
+      # end
+      # @info "going to forward" CUDA.device() typeof(d)
+      # @show loss(m(x), y)
+      @show size(x), size(y)
     end
   end
-  dls = []
-  devs_and_ms = []
-  for (k,dev) in zip(ks, devices)
-    CUDA.device!(dev) do
-      push!(devs_and_ms, (dev, gpu(resnet)))
-      dl = Flux.Data.DataLoader((ns,), buffersize = 5) do x
-        shard = minibatch(nothing, k, nsamples = x, class_idx = 1:1000)
-        CUDA.device!(dev) do
-          gpu(shard)
-        end
-      end
-      push!(dls, dl)
+end
+
+function train_ddp(loss, ds)
+  res = []
+  for (dev, (m, d)) in pairs(ds)
+    t = Threads.@spawn begin
+      # CUDA.device!(dev) do
+      #   @show CUDA.device()
+        train(loss, dev, m, d)
+      # end
     end
+    push!(res, t)
   end
-  (ds_and_ms = devs_and_ms, dls = dls), buffer
+  @show "ended stuff"
+  wait.(res)
 end
 
 
-# function train(loss, dev, m, dl)
-#   CUDA.device!(dev) do
-#     @info "going to forward" CUDA.device()
-#     for d in dl
-#       x, y = d
-#       # gradient(m) do m
-#       #   loss(m(x), y)
-#       # end
-#       # @info "going to forward" CUDA.device() typeof(d)
-#       # @show loss(m(x), y)
-#       @show size(x), size(y)
-#     end
-#   end
-# end
-# 
-# function train_ddp(loss, ds)
-#   res = []
-#   for (dev, (m, d)) in pairs(ds)
-#     t = Threads.@spawn begin
-#       # CUDA.device!(dev) do
-#       #   @show CUDA.device()
-#         train(loss, dev, m, d)
-#       # end
-#     end
-#     push!(res, t)
-#   end
-#   @show "ended stuff"
-#   wait.(res)
-# end
 
 function train(loss, m, dl, opt, dev, (ip, op))
   # STEP 1: Take data from dataloader: this data is on `dev`
@@ -136,12 +119,15 @@ function train(loss, m, dl, opt, dev, (ip, op))
   end
 end
 
+
 _copyto!(::Nothing, ::Nothing) = nothing
 _copyto!(x::Base.RefValue, y::Base.RefValue) = Ref(_copyto!(x[], yp[]))
 _copyto!(x, y) = copyto!(x, y)
 _copyto!(x, ::Nothing) = nothing
 _copyto!(::Nothing, x) = nothing
-
+_copyto!(x::Function, y::Function) = nothing # x
+_copyto!(x::T, y::S) where {T <: Real, S <: Real} = convert(T, y)
+_copyto!(x::T, y::T) where T <: Union{MaxPool, AdaptiveMeanPool, Flux.Zeros} = y
 function markbuffer!(dest, src, dev)
   Functors.fmap(src, dest) do x, y
     _copyto!(y, x)
@@ -156,48 +142,146 @@ function getbuffer!(dest, src, dev)
   end
 end
 
+function step(loss, buffer, dev, m, x, y)
+  gs, = CUDA.device!(dev) do
+    gradient(m -> loss(m(x), y), m)
+  end
+  markbuffer!(buffer[dev], gs, dev)
+  gs
+end
+
 function sync_buffer(buffer)
-  vals = map(first, values(buffer))
-  # vals = collect(values(buffer))
+  # vals = map(first, values(buffer))
+  vals = collect(values(buffer))
   final = reduce(vals[2:end], init = vals[1]) do x,y
     Functors.fmap(x, y) do x, y
        isnothing(x) && return y
        isnothing(y) && return x
-       _accum(x,y)
+       ResNetImageNet._accum(x,y)
     end
   end
-end
-
-function step(buffer, dev, m, x, y)
-  gs, = CUDA.device!(dev) do
-    gradient(m -> ResNetImageNet.loss(m(x), y), m)
+  final = Functors.fmap(final) do x
+    isnothing(x) && return x
+    ResNetImageNet._dodiv(x, Float32(length(vals)))
   end
-  markbuffer!(first(buffer[dev]), gs, dev)
-  # markbuffer!(buffer[dev], gs, dev)
-  gs
+  # once you have the final grads - broadcast them (copy them to every entry in buffer)
+  # note that the grads never leave the HOST, move them to every GPU in the optimisation
+  # step
+  get_tasks = Threads.@spawn begin
+    ts = []
+    for (dev,g) in pairs(buffer)
+      get_task = Threads.@spawn getbuffer!(g, final, dev)
+      push!(ts, get_task)
+    end
+    ts
+  end
+  ft = fetch(get_tasks)
+  wait.(ft)
+  final 
 end
 
-# implementation of the `train` function from above
-# with actual semantics baked in
-# intended to be moved to the train method as pieces finish
-function train(setup, buffer, HOST = CUDA.CuDevice(0))
+log_loss_and_acc(loss, (dev, model), val::Nothing) = nothing
+function log_loss_and_acc(loss, (dev, model), val; k = (1,5,10))
+  l, fw = CUDA.device!(dev) do
+    gval = gpu(val)
+    loss(model(gval[1]), gval[2]), cpu(model(gval[1]))
+  end
+  acc = map(k -> topkaccuracy(fw, val[2]; k = k), k)
+  @info "val_loss" loss=l
+  for (j,a) in zip(k, acc)
+    @info "acc_$j" acc=a
+  end
+end
+
+function train(loss, nt, buffer, opt; val = nothing)
   dls = nt.dls
   ds_and_ms = nt.ds_and_ms
+  sts = nt.sts
   big_batches = zip(dls...)
-  for mbs in big_batches
+  for (j,mbs) in enumerate(big_batches)
+    if j % 10 == 0
+      println("Cycle: $j")
+      log_loss_and_acc(loss, first(ds_and_ms), val)
+    end
     t = Threads.@spawn begin
       t_ = map(ds_and_ms, mbs) do (dev, m), bs
-        @info "results:" dev=dev host=HOST
-        gs = Threads.@spawn step(buffer, dev, m, bs...)
+        gs = Threads.@spawn step(loss, buffer, dev, m, bs...)
       end
     end
     gs = fetch(t)
     wait.(gs)
     final = sync_buffer(buffer)
+
+    # move final grads to every GPU - fetch(g) has the right
+    # grads for dev in it, overwrite with final
+    # and optimise
     get_tasks = map(ds_and_ms, gs) do dnm, g
-     dev, m = dnm
-     get_task = Threads.@spawn getbuffer!(fetch(g), final, dev)
+      t = Threads.@spawn begin
+        dev, m = dnm
+
+        t_ = Threads.@spawn begin
+          g!(fetch(g), final, dev)
+        end
+
+        t_opt = Threads.@spawn begin
+          m, st = CUDA.device!(dev) do
+            opt(m, fetch(t_), sts[dev])
+          end
+          sts[dev] = st
+          m
+        end
+
+        (dev, fetch(t_opt))
+      end
     end
-    ts = fetch.(get_tasks)
+    ds_and_ms = fetch.(get_tasks)
   end
+  map(ds_and_ms) do dnm
+    dev, m = dnm
+    CUDA.device!(dev) do
+      dev, cpu(m)
+    end
+  end
+end
+
+function prepare_training(resnet, key, devices, opt, nsamples;
+	                   HOST = CUDA.CuDevice(0),
+			   cycle = 5,
+			   classes = 1:1000,
+			   buffersize = 5)
+  ds = Dict()
+  ixs = map(shuffle!, collect.(collect(Iterators.partition(1:size(key, 1), size(key, 1) ÷ length(devices)))))[1:length(devices)]
+  ks = map(x -> @view(key[x,:]), ixs)
+  ns = Iterators.repeated(nsamples, cycle) # ntuple(_ -> nsamples, 5)
+  buffer = Dict()
+  zmodel = destruct(resnet)
+  st = ResNetImageNet.Optimisers.state(opt, resnet)
+  for dev in devices
+    Threads.@spawn begin
+      buffer[dev] = CUDA.device!(HOST) do
+        gpu(zmodel)
+      end
+    end
+  end
+  dls = []
+  devs_and_ms = []
+  sts = Dict()
+  for (k,dev) in zip(ks, devices)
+    # Threads.@spawn begin
+      CUDA.device!(dev) do
+        # @show CUDA.device()
+        push!(devs_and_ms, (dev, gpu(resnet)))
+        # devs_and_ms[dev] = gpu(resnet), gpu(st)
+        sts[dev] = gpu(st)
+        dl = Flux.Data.DataLoader((ns,), buffersize = buffersize) do x
+          shard = minibatch(nothing, k, nsamples = x, class_idx = classes)
+          CUDA.device!(dev) do
+            gpu(shard)
+          end
+        end
+	push!(dls, dl)
+      end
+    # end
+  end
+  (ds_and_ms = devs_and_ms, dls = dls, sts = sts), buffer
 end

--- a/src/imagenet.jl
+++ b/src/imagenet.jl
@@ -4,6 +4,13 @@ using DataSets
 import FileIO
 using .Threads
 
+const IMAGENET_BASE = "/home/dhairyalgandhi/imagenet"
+const ILSVRC = "ILSVRC"
+const ILSVRC_BASE = joinpath(IMAGENET_BASE, "ILSVRC")
+const TASK = "CLS-LOC"
+const ANNOTATIONS = "Annotations"
+const BASE_PATH = "/home/dhairyalgandhi/imagenet/ILSVRC/Data/CLS-LOC"
+
 function labels(data_tree, labels_file = path"LOC_synset_mapping.txt")
   lines = open(IO, data_tree[labels_file]) do io 
     readlines(io)
@@ -31,6 +38,14 @@ function fproc(data_tree, dest, path)
   dest .= Flux.normalise(dropdims(x, dims = 4))
 end
 
+function fproc(dest::AbstractArray, path, dataset::AbstractString)
+  # try
+  dest .= Flux.normalise(dropdims(Metalhead.preprocess(joinpath(BASE_PATH, dataset, path)), dims = 4))
+  # catch e
+  #   @show e, catch_backtrace()
+  # end
+end
+
 function minibatch(data_tree, img_idxs, img_classes;
                    class_idx = 1:200, dataset = "train")
   arr = zeros(Float32, 224, 224, 3, length(img_idxs))
@@ -38,19 +53,28 @@ function minibatch(data_tree, img_idxs, img_classes;
 
   ## For some reason @sync -- @async created a deadlock.
   ## The run had to be stopped after 1hr and nothing seemed to be happening.
-  @sync for (i,p) in enumerate(ps)
-    Threads.@spawn fproc(data_tree, @view(arr[:,:,:,i]), p)
+  @sync for (i,p) in zip(eachslice(arr, dims =4), ps)
+    # fproc(data_tree, @view(arr[:,:,:,i]), p)
+    u = Threads.@spawn fproc(i, p, dataset)
   end
   arr, Flux.onehotbatch(img_classes, class_idx)
 end
 
-function makepaths(imgs, dataset, base = ["ILSVRC", "Data", "CLS-LOC"])
+function makepaths(img, dataset)
   if dataset == "train"
-    return DataSets.RelPath([base..., dataset, first(split(imgs, "_", limit = 2)), imgs * ".JPEG"])
+    joinpath(first(split(img, "_", limit = 2)), img * ".JPEG")
   elseif dataset == "val"
-    return DataSets.RelPath([base..., dataset, img * ".JPEG"])
+    img * ".JPEG"
   end
 end
+
+# function makepaths(imgs, dataset, base = ["ILSVRC", "Data", "CLS-LOC"])
+#   if dataset == "train"
+#     return DataSets.RelPath([base..., dataset, first(split(imgs, "_", limit = 2)), imgs * ".JPEG"])
+#   elseif dataset == "val"
+#     return DataSets.RelPath([base..., dataset, img * ".JPEG"])
+#   end
+# end
 
 function train_solutions(data_tree, train_sol_file = path"LOC_train_solution.csv", classes = 1:200)
   df = open(IO, data_tree[train_sol_file]) do io

--- a/src/overloads.jl
+++ b/src/overloads.jl
@@ -1,13 +1,26 @@
-function Optimisers.update(o, x::T, x̄, state) where T
+# function Optimisers.update(o, x::T, x̄, state) where T
+#   if x̄ === nothing
+#     return x, state
+#   elseif Functors.isleaf(x)
+#     return Optimisers._update(o, x, x̄, state)
+#   else
+#     x̄, _  = _functor(typeof(x), x̄)
+#     x, restructure = _functor(typeof(x), x)
+#     xstate = map((x, x̄, state) -> Optimisers.update(o, x, x̄, state), x, x̄, state)
+#     return restructure(map(first, xstate)), map(x -> x[2], xstate)
+#   end
+# end
+
+function Optimisers.update(o, state, x::T, x̄) where T
   if x̄ === nothing
-    return x, state
+    return state, x
   elseif Functors.isleaf(x)
-    return Optimisers._update(o, x, x̄, state)
+    return Optimisers._update(o, state, x, x̄)
   else
     x̄, _  = _functor(typeof(x), x̄)
     x, restructure = _functor(typeof(x), x)
-    xstate = map((x, x̄, state) -> Optimisers.update(o, x, x̄, state), x, x̄, state)
-    return restructure(map(first, xstate)), map(x -> x[2], xstate)
+    xstate = map((state, x, x̄) -> Optimisers.update(o, state, x, x̄), state, x, x̄)
+    return map(first, xstate), restructure(map(x -> x[2], xstate))
   end
 end
 
@@ -28,10 +41,19 @@ _functor(T, ref::Base.RefValue) = Functors.functor(T, ref.x)
 Optimisers.init(o, x) = nothing
 
 _accum(x, y) = Zygote.accum(x, y)
+_accum(x::T, y::T) where T <: Union{MaxPool, AdaptiveMeanPool, MeanPool, Flux.Zeros} = y
+_accum(x::Function, y::Function) = x
 _accum(x::Base.RefValue, y::Base.RefValue) = Ref(Zygote.accum(x.x, y.x))
 
 _dodiv(::Nothing, y) = nothing
 _dodiv(nt::NamedTuple, y) = NamedTuple{keys(nt)}((_dodiv(nt[k], y) for k in keys(nt)))
 _dodiv(x, y) = x / y
+_dodiv(x::Function, y) = x 
 _dodiv(x::Base.RefValue, y::Real) = Ref(_dodiv(x.x, y))
 _dodiv(x::AbstractArray, y::Real) = x / y
+_dodiv(x::T, y) where T <: Union{MaxPool, AdaptiveMeanPool, Flux.Zeros, MeanPool} = x
+
+_show_stats(::Nothing) = nothing
+_show_stats(nt::NamedTuple) = NamedTuple{keys(nt)}((_show_stats(nt[k]) for k in keys(nt)))
+_show_stats(x) = @show mean(x), sum(x), maximum(x), minimum(x)
+_show_stats(x::Base.RefValue) = Ref(_show_stats(x[]))

--- a/src/overloads.jl
+++ b/src/overloads.jl
@@ -1,28 +1,28 @@
-# function Optimisers.update(o, x::T, x̄, state) where T
-#   if x̄ === nothing
-#     return x, state
-#   elseif Functors.isleaf(x)
-#     return Optimisers._update(o, x, x̄, state)
-#   else
-#     x̄, _  = _functor(typeof(x), x̄)
-#     x, restructure = _functor(typeof(x), x)
-#     xstate = map((x, x̄, state) -> Optimisers.update(o, x, x̄, state), x, x̄, state)
-#     return restructure(map(first, xstate)), map(x -> x[2], xstate)
-#   end
-# end
-
-function Optimisers.update(o, state, x::T, x̄) where T
+function Optimisers.update(o, x::T, x̄, state) where T
   if x̄ === nothing
-    return state, x
+    return x, state
   elseif Functors.isleaf(x)
-    return Optimisers._update(o, state, x, x̄)
+    return Optimisers._update(o, x, x̄, state)
   else
     x̄, _  = _functor(typeof(x), x̄)
     x, restructure = _functor(typeof(x), x)
-    xstate = map((state, x, x̄) -> Optimisers.update(o, state, x, x̄), state, x, x̄)
-    return map(first, xstate), restructure(map(x -> x[2], xstate))
+    xstate = map((x, x̄, state) -> Optimisers.update(o, x, x̄, state), x, x̄, state)
+    return restructure(map(first, xstate)), map(x -> x[2], xstate)
   end
 end
+
+# function Optimisers.update(o, state, x::T, x̄) where T
+#   if x̄ === nothing
+#     return state, x
+#   elseif Functors.isleaf(x)
+#     return Optimisers._update(o, state, x, x̄)
+#   else
+#     x̄, _  = _functor(typeof(x), x̄)
+#     x, restructure = _functor(typeof(x), x)
+#     xstate = map((state, x, x̄) -> Optimisers.update(o, state, x, x̄), state, x, x̄)
+#     return map(first, xstate), restructure(map(x -> x[2], xstate))
+#   end
+# end
 
 function Optimisers.state(o, x)
   if Functors.isleaf(x)

--- a/src/preprocess.jl
+++ b/src/preprocess.jl
@@ -1,0 +1,80 @@
+using Images, ImageMagick
+
+const deps = joinpath(@__DIR__, "..", "deps")
+const url = "https://github.com/FluxML/Metalhead.jl/releases/download/Models"
+
+function testimgs end
+function valimgs end
+
+function getweights(name)
+  mkpath(deps)
+  cd(deps) do
+    if name == "vgg19.bson"
+        isfile(name) || Base.download("$url/$name", name)
+    else
+        loc = "https://github.com/FluxML/Metalhead.jl/releases/download/v0.1.1"
+        isfile(name) || Base.download("$loc/$name", name)
+    end
+  end
+end
+
+function weights(name)
+  getweights(name)
+  BSON.load(joinpath(deps, name))
+end
+
+load_img(im::AbstractMatrix{<:Color}) = im
+load_img(str::AbstractString) = load(str)
+
+# Resize an image such that its smallest dimension is the given length
+function resize_smallest_dimension(im, len)
+  reduction_factor = len/minimum(size(im)[1:2])
+  new_size = size(im)
+  new_size = (
+	            round(Int, size(im,1)*reduction_factor),
+		          round(Int, size(im,2)*reduction_factor),
+			    )
+  if reduction_factor < 1.0
+    # Images.jl's imresize() needs to first lowpass the image, it won't do it for us
+    im = imfilter(im, KernelFactors.gaussian(0.75/reduction_factor), Inner())
+  end
+  return imresize(im, new_size)
+end
+
+# Take the len-by-len square of pixels at the center of image `im`
+function center_crop(im, len)
+  l2 = div(len,2)
+  adjust = len % 2 == 0 ? 1 : 0
+  return im[div(end,2)-l2:div(end,2)+l2-adjust,div(end,2)-l2:div(end,2)+l2-adjust]
+end
+
+function preprocess(im::AbstractMatrix{<:AbstractRGB})
+  # Resize such that smallest edge is 256 pixels long
+  im = resize_smallest_dimension(im, 256)
+
+  # Center-crop to 224x224
+  im = center_crop(im, 224)
+
+  # Convert to channel view and normalize (these coefficients taken
+						   # from PyTorch's ImageNet normalization code)
+  μ = [0.485, 0.456, 0.406]
+  σ = [0.229, 0.224, 0.225]
+  im = (channelview(im) .- μ)./σ
+
+  # Convert from CHW (Image.jl's channel ordering) to WHCN (Flux.jl's ordering)
+  # and enforce Float32, as that seems important to Flux
+  return Float32.(permutedims(im, (3, 2, 1))[:,:,:,:].*255)
+end
+
+preprocess(im) = preprocess(load(im))
+preprocess(im::AbstractMatrix) = preprocess(RGB.(im))
+
+forward(model, im) = vec(model(preprocess(RGB.(im))))
+
+topk(ps::AbstractVector, k::Int = 5) = topk(1:length(ps), ps, k)
+topk(classes, ps::AbstractVector, k::Int = 5) = sort(collect(zip(classes, ps)), by = x -> -x[2])[1:k]
+
+make_fname(s::AbstractMatrix{<:Color}) = ""
+make_fname(s::String) = s
+
+ground_truth(m, s::Union{AbstractMatrix, AbstractString}, result) = (nothing, 0.)


### PR DESCRIPTION
Since CUDA.jl can handle several GPUs from a single process via tasks and since according to @maleadt it will be easier to write for, let's move away from using processes to train these models. This PR adds the first building blocks for the task based mechanism, and it can potentially be very useful. One of the big ones would be if we can avoid all the serialisation cost we pay currently to sync our gradients. If that can be done via a NCCL backend, it should save at least some cost in terms of the data movement. it should also technically make it easier to implement gradient overlapping to speed up training.

Currently it seems that the `prepare_training` function only allocates the models on the same GPU, whereas the data is distributed as expected.