### PR TITLE
Respect available devices

### DIFF
--- a/src/ddp_tasks.jl
+++ b/src/ddp_tasks.jl
@@ -256,7 +256,7 @@ function train(loss, nt, buffer, opt; val = nothing, sched = identity)
 end
 
 function prepare_training(resnet, key, devices, opt, nsamples;
-	                   HOST = CUDA.CuDevice(0),
+	                   HOST = first(devices),
                            epochs = nothing,
 			   cycle = 5,
 			   classes = 1:1000,


### PR DESCRIPTION
Pick the first device from the list of available devices rather than hardcoding the device to sync all the buffers on. Allows users to supply only a select range of devices with out using `CUDA_VISIBLE_DEVICES`