### PR TITLE
Report errors in async processes

### DIFF
--- a/src/ddp_tasks.jl
+++ b/src/ddp_tasks.jl
@@ -212,7 +212,7 @@ function train(loss, nt, buffer, opt; val = nothing, sched = identity)
       ts = []
       for ((dev,m), bs) in zip(ds_and_ms, mbs)
         gs = Threads.@spawn train_step(loss, buffer, dev, m, bs...)
-        push!(ts, gs)
+        push!(ts, Base.errormonitor(gs))
       end
       gs = ts
       wait.(gs)
@@ -231,10 +231,10 @@ function train(loss, nt, buffer, opt; val = nothing, sched = identity)
             sts[dev] = st
             m
           end
-          (dev, fetch(t_opt))
+          (dev, fetch(Base.errormonitor(t_opt)))
         end
       end
-      ds_and_ms = fetch.(get_tasks)
+      ds_and_ms = fetch.(Base.errormonitor.(get_tasks))
 
     catch e
       if e isa TaskFailedException && e.task.exception isa CUDA.OutOfGPUMemoryError

--- a/src/ddp_tasks.jl
+++ b/src/ddp_tasks.jl
@@ -233,8 +233,9 @@ function train(loss, nt, buffer, opt; val = nothing, sched = identity)
           end
           (dev, fetch(Base.errormonitor(t_opt)))
         end
+        Base.errormonitor(t)
       end
-      ds_and_ms = fetch.(Base.errormonitor.(get_tasks))
+      ds_and_ms = fetch.(get_tasks)
 
     catch e
       if e isa TaskFailedException && e.task.exception isa CUDA.OutOfGPUMemoryError


### PR DESCRIPTION
Report errors in asynchronous processes that can otherwise result in silent hangs. This also prints when a GPU reports an OOM which should have been recoverable. This, however, does not stop the training process.