### PR TITLE
add `at-device!` similar to `at-spawnat`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,15 @@
+macro device!(dev, ex)
+  if CUDA.functional()
+    return quote
+      CUDA.device!($(esc(dev))) do
+        $(esc(ex))
+      end
+    end
+  else
+    return ex
+  end
+end
+
 function maxk!(ix, a, k; initialized=false)
   partialsortperm!(ix, a, 1:k, rev=true, initialized=initialized)
   @views collect(zip(ix[1:k], a[ix[1:k]]))


### PR DESCRIPTION
Adds a wrapper utility around `CUDA.device!` - macro called `@device! dev ex` which can checks for whether CUDA is functional and generates code to make it easy to run code even when no GPU is available. This comes at a compilation penalty but should help with making tests work as in #39.

Should be followed up by tests in #39.